### PR TITLE
Switch homepage rendering to Twig

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,6 +1,6 @@
 {# Базовый шаблон для Twig, определяющий каркас HTML-страницы. #}
 <!DOCTYPE html>
-<html>
+<html{% block html_attributes %} lang="en"{% endblock %}>
     <head>
         <meta charset="UTF-8">
         <title>{% block title %}Welcome!{% endblock %}</title>
@@ -11,7 +11,7 @@
         {% block javascripts %}
         {% endblock %}
     </head>
-    <body>
+    <body{% block body_attributes %}{% endblock %}>
         {% block body %}{% endblock %}
     </body>
 </html>

--- a/templates/homepage.html.twig
+++ b/templates/homepage.html.twig
@@ -1,15 +1,19 @@
 {# Шаблон приветственной страницы Codex с оформлением Tailwind CSS. #}
-<!DOCTYPE html>
-<html lang="ru" class="h-full bg-slate-900">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ pageTitle }}</title>
+{% extends 'base.html.twig' %}
+
+{% block html_attributes %} lang="ru" class="h-full bg-slate-900"{% endblock %}
+{% block body_attributes %} class="h-full text-slate-100"{% endblock %}
+
+{% block title %}{{ pageTitle }}{% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" rel="stylesheet">
-</head>
-<body class="h-full text-slate-100">
+{% endblock %}
+
+{% block body %}
 <div class="min-h-full flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
     <div class="max-w-2xl w-full bg-slate-800/60 backdrop-blur shadow-xl rounded-2xl border border-slate-700 p-10">
         <div class="flex items-center justify-between gap-4 border-b border-slate-700 pb-6 mb-6">
@@ -53,5 +57,4 @@
         </div>
     </div>
 </div>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- render the homepage through a Twig template using Tailwind-styled sections
- enable Twig bundle configuration for rendering
- derive the homepage template from the shared base layout to reuse page chrome

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68cc4dd9cbb0832ea79e3c6c97c04937