### PR TITLE
Rename SQLite connection accessor

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,7 +20,7 @@ services:
             - '../src/Greeting/'
             - '../src/Kernel.php'
 
-    App\Database\SqliteDatetime:
+    App\Database\SqliteConnection:
         arguments:
             $databasePath: '%app.sqlite.database_path%'
 

--- a/src/Database/SqliteConnection.php
+++ b/src/Database/SqliteConnection.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Database;
+
+use PDO;
+use PDOException;
+use RuntimeException;
+
+/**
+ * Представляет поставщика PDO-подключения к файлу SQLite.
+ */
+final class SqliteConnection
+{
+    private ?PDO $connection = null;
+
+    /**
+     * Запоминает путь к SQLite-файлу для последующих подключений.
+     */
+    public function __construct(
+        private readonly string $databasePath,
+    ) {
+    }
+
+    /**
+     * Возвращает подготовленный объект PDO для работы с SQLite.
+     */
+    public function db(): PDO
+    {
+        return $this->connection ??= $this->createConnection();
+    }
+
+    /**
+     * Создаёт и настраивает PDO-подключение к файлу SQLite.
+     */
+    private function createConnection(): PDO
+    {
+        $directory = dirname($this->databasePath);
+
+        if (!is_dir($directory)) {
+            if (!mkdir($directory, 0777, true) && !is_dir($directory)) {
+                throw new RuntimeException(sprintf('Не удалось создать каталог "%s" для файла SQLite.', $directory));
+            }
+        }
+
+        try {
+            $connection = new PDO('sqlite:' . $this->databasePath);
+        } catch (PDOException $exception) {
+            throw new RuntimeException(sprintf('Не удалось открыть SQLite-файл "%s".', $this->databasePath), 0, $exception);
+        }
+
+        $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+        return $connection;
+    }
+}

--- a/src/Database/SqliteConnection.php
+++ b/src/Database/SqliteConnection.php
@@ -7,7 +7,7 @@ use PDOException;
 use RuntimeException;
 
 /**
- * Представляет поставщика PDO-подключения к файлу SQLite.
+ * Поставщик PDO-подключения к файлу SQLite.
  */
 final class SqliteConnection
 {

--- a/src/Database/SqliteDatetime.php
+++ b/src/Database/SqliteDatetime.php
@@ -13,13 +13,11 @@ use Throwable;
  */
 final class SqliteDatetime
 {
-    private ?PDO $connection = null;
-
     /**
-     * Запоминает путь к SQLite-файлу для получения времени.
+     * Инициализирует источник времени объектом подключения SQLite.
      */
     public function __construct(
-        private readonly string $databasePath,
+        private readonly SqliteConnection $sqliteConnection,
     ) {
     }
 
@@ -28,7 +26,7 @@ final class SqliteDatetime
      */
     public function currentDateTime(): DateTimeImmutable
     {
-        $connection = $this->connection ??= $this->createConnection();
+        $connection = $this->sqliteConnection->db();
 
         try {
             $statement = $connection->query("SELECT datetime('now') AS current_datetime");
@@ -49,28 +47,4 @@ final class SqliteDatetime
         }
     }
 
-    /**
-     * Создаёт и настраивает PDO-подключение к файлу SQLite.
-     */
-    private function createConnection(): PDO
-    {
-        $directory = dirname($this->databasePath);
-
-        if (!is_dir($directory)) {
-            if (!mkdir($directory, 0777, true) && !is_dir($directory)) {
-                throw new RuntimeException(sprintf('Не удалось создать каталог "%s" для файла SQLite.', $directory));
-            }
-        }
-
-        try {
-            $connection = new PDO('sqlite:' . $this->databasePath);
-        } catch (PDOException $exception) {
-            throw new RuntimeException(sprintf('Не удалось открыть SQLite-файл "%s".', $this->databasePath), 0, $exception);
-        }
-
-        $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
-
-        return $connection;
-    }
 }

--- a/tests/Database/SqliteDatetimeTest.php
+++ b/tests/Database/SqliteDatetimeTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Database;
 
+use App\Database\SqliteConnection;
 use App\Database\SqliteDatetime;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +19,8 @@ class SqliteDatetimeTest extends TestCase
         $databaseDirectory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'codex-sqlite-' . uniqid('', true);
         $databasePath = $databaseDirectory . DIRECTORY_SEPARATOR . 'time.db';
 
-        $sqliteDatetime = new SqliteDatetime($databasePath);
+        $sqliteConnection = new SqliteConnection($databasePath);
+        $sqliteDatetime = new SqliteDatetime($sqliteConnection);
         $dateTime = $sqliteDatetime->currentDateTime();
 
         $this->assertLessThan(5, abs($dateTime->getTimestamp() - time()));


### PR DESCRIPTION
## Summary
- rename the SQLite connection accessor to a concise db() method
- update SqliteDatetime to call the new accessor name

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68ccfa54cf70832e93c0d16a44f9ab9b