### PR TITLE
Remove documentation button from homepage

### DIFF
--- a/templates/homepage.html.twig
+++ b/templates/homepage.html.twig
@@ -47,12 +47,7 @@
                         {% endfor %}
                     </div>
                 </div>
-                <div class="mt-10 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                    <a href="{{ documentationUrl }}"
-                       class="inline-flex items-center justify-center rounded-full bg-sky-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-500/30 transition hover:bg-sky-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-400 focus:ring-offset-slate-900"
-                       target="_blank" rel="noreferrer">
-                        Читать документацию
-                    </a>
+                <div class="mt-10 flex flex-col sm:flex-row sm:items-center sm:justify-end gap-4">
                     <div class="text-xs text-slate-500">
                         © {{ "now"|date('Y') }} agorlov
                     </div>


### PR DESCRIPTION
## Summary
- remove the "Читать документацию" link from the homepage footer
- keep the footer layout while showing only the copyright notice

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd10710138832eae76c979617ddc64