### PR TITLE
Move SQLite database to project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /config/secrets/prod/prod.decrypt.private.php
 /public/bundles/
 /var/
-/db-data/app.db
+/app.db
 /vendor/
 ###< symfony/framework-bundle ###
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -2,7 +2,7 @@
 # Files in the packages/ subdirectory configure your dependencies.
 
 parameters:
-    app.sqlite.database_path: '%kernel.project_dir%/db-data/app.db'
+    app.sqlite.database_path: '%kernel.project_dir%/app.db'
     app.sqlite.migrations_path: '%kernel.project_dir%/db-data/migrations'
 
 services:

--- a/src/Controller/HelloController.php
+++ b/src/Controller/HelloController.php
@@ -18,7 +18,7 @@ use Symfony\Component\Routing\Attribute\Route;
 final class HelloController extends AbstractController
 {
     private const DEFAULT_GREETING_LANGUAGE = 'ru';
-    private const DATABASE_PATH = __DIR__ . '/../../db-data/app.db';
+    private const DATABASE_PATH = __DIR__ . '/../../app.db';
     private const MIGRATIONS_DIRECTORY = __DIR__ . '/../../db-data/migrations';
 
     private readonly SqliteDatetime $sqliteDatetime;

--- a/tests/Functional/HelloControllerTest.php
+++ b/tests/Functional/HelloControllerTest.php
@@ -12,16 +12,13 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
  */
 class HelloControllerTest extends WebTestCase
 {
-    private string $databaseDirectory;
-
     private string $databasePath;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->databaseDirectory = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'db-data';
-        $this->databasePath = $this->databaseDirectory . DIRECTORY_SEPARATOR . 'app.db';
+        $this->databasePath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'app.db';
 
         $this->removeDatabaseArtifacts();
     }
@@ -29,10 +26,6 @@ class HelloControllerTest extends WebTestCase
     protected function tearDown(): void
     {
         $this->removeDatabaseArtifacts();
-
-        if (is_dir($this->databaseDirectory) && $this->isDirectoryEmpty($this->databaseDirectory)) {
-            rmdir($this->databaseDirectory);
-        }
 
         parent::tearDown();
     }
@@ -161,17 +154,4 @@ class HelloControllerTest extends WebTestCase
         }
     }
 
-    /**
-     * Проверяет, что каталог пустой (кроме псевдоссылок).
-     */
-    private function isDirectoryEmpty(string $directory): bool
-    {
-        $contents = scandir($directory);
-
-        if ($contents === false) {
-            return true;
-        }
-
-        return count(array_diff($contents, ['.', '..'])) === 0;
-    }
 }


### PR DESCRIPTION
## Summary
- point the application and configuration to `app.db` in the project root
- keep the visit log migrations under `db-data/migrations` while updating the controller constant
- simplify the functional test cleanup for the relocated database file

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68cd9ca5b130832eaadc5486cb5d1d50