### PR TITLE
Rename SqliteConnection to SqliteDB

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -21,13 +21,13 @@ services:
             - '../src/Greeting/'
             - '../src/Kernel.php'
 
-    App\Database\SqliteConnection:
+    App\Database\SqliteDB:
         arguments:
             $databasePath: '%app.sqlite.database_path%'
 
     App\Database\SqliteMigrations:
         arguments:
-            $sqliteConnection: '@App\Database\SqliteConnection'
+            $sqliteConnection: '@App\Database\SqliteDB'
 
     App\VisitLogbook:
         arguments:

--- a/src/Controller/HelloController.php
+++ b/src/Controller/HelloController.php
@@ -2,7 +2,7 @@
 
 namespace App\Controller;
 
-use App\Database\SqliteConnection;
+use App\Database\SqliteDB;
 use App\Database\SqliteDatetime;
 use App\Database\SqliteMigrations;
 use App\Greeting\RandomCodexGreeting;
@@ -30,7 +30,7 @@ final class HelloController extends AbstractController
      */
     public function __construct()
     {
-        $sqliteConnection = new SqliteConnection(self::DATABASE_PATH);
+        $sqliteConnection = new SqliteDB(self::DATABASE_PATH);
         $sqliteMigrations = new SqliteMigrations($sqliteConnection);
 
         $this->sqliteDatetime = new SqliteDatetime($sqliteConnection);

--- a/src/Database/SqliteDB.php
+++ b/src/Database/SqliteDB.php
@@ -9,7 +9,7 @@ use RuntimeException;
 /**
  * Поставщик PDO-подключения к файлу SQLite.
  */
-final class SqliteConnection
+final class SqliteDB
 {
     private ?PDO $connection = null;
 

--- a/src/Database/SqliteDatetime.php
+++ b/src/Database/SqliteDatetime.php
@@ -17,7 +17,7 @@ final class SqliteDatetime
      * Инициализирует источник времени объектом подключения SQLite.
      */
     public function __construct(
-        private readonly SqliteConnection $sqliteConnection,
+        private readonly SqliteDB $sqliteConnection,
     ) {
     }
 

--- a/src/Database/SqliteMigrations.php
+++ b/src/Database/SqliteMigrations.php
@@ -16,7 +16,7 @@ final class SqliteMigrations
      * Запоминает поставщика SQLite-подключения для выполнения миграций.
      */
     public function __construct(
-        private readonly SqliteConnection $sqliteConnection,
+        private readonly SqliteDB $sqliteConnection,
     ) {
     }
 

--- a/src/VisitLogbook.php
+++ b/src/VisitLogbook.php
@@ -2,7 +2,7 @@
 
 namespace App;
 
-use App\Database\SqliteConnection;
+use App\Database\SqliteDB;
 use App\Database\SqliteMigrations;
 use PDOException;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,7 +19,7 @@ final class VisitLogbook
      * Принимает подключение к SQLite, применяет миграции и готовит журнал посещений.
      */
     public function __construct(
-        private readonly SqliteConnection $sqliteConnection,
+        private readonly SqliteDB $sqliteConnection,
         private readonly SqliteMigrations $sqliteMigrations,
         private readonly string $migrationsDirectory,
     ) {

--- a/tests/Database/SqliteDatetimeTest.php
+++ b/tests/Database/SqliteDatetimeTest.php
@@ -2,7 +2,7 @@
 
 namespace App\Tests\Database;
 
-use App\Database\SqliteConnection;
+use App\Database\SqliteDB;
 use App\Database\SqliteDatetime;
 use PHPUnit\Framework\TestCase;
 
@@ -19,7 +19,7 @@ class SqliteDatetimeTest extends TestCase
         $databaseDirectory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'codex-sqlite-' . uniqid('', true);
         $databasePath = $databaseDirectory . DIRECTORY_SEPARATOR . 'time.db';
 
-        $sqliteConnection = new SqliteConnection($databasePath);
+        $sqliteConnection = new SqliteDB($databasePath);
         $sqliteDatetime = new SqliteDatetime($sqliteConnection);
         $dateTime = $sqliteDatetime->currentDateTime();
 

--- a/tests/Functional/HelloControllerTest.php
+++ b/tests/Functional/HelloControllerTest.php
@@ -2,7 +2,7 @@
 
 namespace App\Tests\Functional;
 
-use App\Database\SqliteConnection;
+use App\Database\SqliteDB;
 use App\Greeting\RandomCodexGreeting;
 use ReflectionClass;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -123,7 +123,7 @@ class HelloControllerTest extends WebTestCase
 
         $this->assertResponseIsSuccessful();
 
-        $sqliteConnection = new SqliteConnection($this->databasePath);
+        $sqliteConnection = new SqliteDB($this->databasePath);
         $connection = $sqliteConnection->db();
 
         $countStatement = $connection->query('SELECT COUNT(*) AS aggregate FROM visit_log');

--- a/tests/VisitLogbookTest.php
+++ b/tests/VisitLogbookTest.php
@@ -2,7 +2,7 @@
 
 namespace App\Tests;
 
-use App\Database\SqliteConnection;
+use App\Database\SqliteDB;
 use App\Database\SqliteMigrations;
 use App\VisitLogbook;
 use PDO;
@@ -47,7 +47,7 @@ class VisitLogbookTest extends TestCase
      */
     public function testRecordVisitCreatesTableAndStoresEntry(): void
     {
-        $sqliteConnection = new SqliteConnection($this->databasePath);
+        $sqliteConnection = new SqliteDB($this->databasePath);
         $sqliteMigrations = new SqliteMigrations($sqliteConnection);
         $visitLogbook = new VisitLogbook($sqliteConnection, $sqliteMigrations, $this->migrationsDirectory);
 


### PR DESCRIPTION
## Summary
- rename the SQLite connection provider class to `SqliteDB`
- update service wiring and runtime usage to rely on the new class name
- adjust functional and unit tests to reference `SqliteDB`

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68cd9cb45f7c832eb644344223d551e6