### PR TITLE
Fix SQLite configuration after manual merge

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -2,7 +2,7 @@
 # Files in the packages/ subdirectory configure your dependencies.
 
 parameters:
-    app.sqlite.database_path: '%kernel.project_dir%/app.db'
+    app.sqlite.database_path: '%kernel.project_dir%/db-data/app.db'
     app.sqlite.migrations_path: '%kernel.project_dir%/db-data/migrations'
 
 services:

--- a/src/Controller/HelloController.php
+++ b/src/Controller/HelloController.php
@@ -17,25 +17,21 @@ use Symfony\Component\Routing\Attribute\Route;
 final class HelloController extends AbstractController
 {
     private const DEFAULT_GREETING_LANGUAGE = 'ru';
-    private const DATABASE_PATH = __DIR__ . '/../../app.db';
-    private const MIGRATIONS_DIRECTORY = __DIR__ . '/../../db-data/migrations';
-
+    private const SQLITE_DATABASE_RELATIVE_PATH = '/db-data/app.db';
 
     private readonly SqliteDatetime $sqliteDatetime;
-
     private readonly VisitLogbook $visitLogbook;
 
     /**
-     * Инициализирует контроллер источником времени SQLite и журналом посещений.
+     * Собирает контроллер с собственными объектами работы с SQLite.
      */
     public function __construct()
     {
-        $this->sqliteDatetime = new SqliteDatetime(
-            new SqliteDB(self::DATABASE_PATH)
-        );
-        $this->visitLogbook = new VisitLogbook(
-            new SqliteDB(self::DATABASE_PATH)
-        );
+        $projectDirectory = dirname(__DIR__, 2);
+        $sqliteDatabase = new SqliteDB($projectDirectory . self::SQLITE_DATABASE_RELATIVE_PATH);
+
+        $this->sqliteDatetime = new SqliteDatetime($sqliteDatabase);
+        $this->visitLogbook = new VisitLogbook($sqliteDatabase);
     }
 
     /**

--- a/tests/Functional/HelloControllerTest.php
+++ b/tests/Functional/HelloControllerTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Functional;
 
 use App\Database\SqliteDB;
+use App\Database\SqliteMigrations;
 use App\Greeting\RandomCodexGreeting;
 use ReflectionClass;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;


### PR DESCRIPTION
## Summary
- point the SQLite service parameter to the db-data directory used in tests and migrations
- construct the VisitLogbook and SqliteDatetime dependencies directly inside HelloController's constructor instead of using dependency injection
- fix HelloControllerTest to import the application SqliteMigrations helper

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68cdb2e50f7c832e9321d1668fff35c6