### PR TITLE
Add streaming chat experience

### DIFF
--- a/public/js/llm-chat-streaming.js
+++ b/public/js/llm-chat-streaming.js
@@ -1,0 +1,393 @@
+/* Скрипт фронтенда для стриминговой версии LLM-чата. */
+
+(function () {
+    'use strict';
+
+    function parseSseEvent(rawEvent) {
+        const lines = rawEvent.split(/\n/);
+        const dataParts = [];
+
+        for (let i = 0; i < lines.length; i += 1) {
+            const originalLine = lines[i];
+            if (!originalLine) {
+                continue;
+            }
+
+            const line = originalLine.replace(/\r$/, '');
+            if (line.startsWith(':')) {
+                continue;
+            }
+
+            if (line.startsWith('data:')) {
+                dataParts.push(line.slice(5).trimStart());
+            }
+        }
+
+        if (dataParts.length === 0) {
+            return null;
+        }
+
+        const payload = dataParts.join('\n').trim();
+        if (payload === '') {
+            return null;
+        }
+
+        try {
+            return JSON.parse(payload);
+        } catch (error) {
+            return null;
+        }
+    }
+
+    async function startStreamingRequest(url, payload, handlers) {
+        const onToken = handlers.onToken || function () {};
+        const onDone = handlers.onDone || function () {};
+        const onError = handlers.onError || function () {};
+
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'text/event-stream',
+            },
+            body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+            let message = `Ошибка обращения к модели (код ${response.status}).`;
+
+            try {
+                const data = await response.json();
+                if (data && typeof data.error === 'string') {
+                    message = data.error;
+                }
+            } catch (error) {
+                // Игнорируем ошибки парсинга ответа.
+            }
+
+            onError(message);
+
+            return;
+        }
+
+        if (!response.body) {
+            onError('Потоковый ответ недоступен.');
+
+            return;
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        let shouldStop = false;
+        let hasEnded = false;
+
+        const finishWithDone = function () {
+            if (hasEnded) {
+                return;
+            }
+
+            hasEnded = true;
+            onDone();
+        };
+
+        const finishWithError = function (message) {
+            if (hasEnded) {
+                return;
+            }
+
+            hasEnded = true;
+            onError(message);
+        };
+
+        const handleRawEvent = function (rawEvent) {
+            const parsed = parseSseEvent(rawEvent);
+            if (!parsed) {
+                return;
+            }
+
+            const eventType = typeof parsed.event === 'string' ? parsed.event : 'token';
+
+            if (eventType === 'token') {
+                const text = typeof parsed.text === 'string' ? parsed.text : '';
+                if (text !== '' && !hasEnded) {
+                    onToken(text);
+                }
+
+                return;
+            }
+
+            if (eventType === 'error') {
+                const message = typeof parsed.message === 'string'
+                    ? parsed.message
+                    : 'Модель завершила поток с ошибкой.';
+                finishWithError(message);
+                shouldStop = true;
+
+                return;
+            }
+
+            if (eventType === 'done') {
+                finishWithDone();
+                shouldStop = true;
+            }
+        };
+
+        const processBuffer = function (textBuffer) {
+            let workingBuffer = textBuffer;
+
+            while (!shouldStop) {
+                const separatorPosition = workingBuffer.indexOf('\n\n');
+                if (separatorPosition === -1) {
+                    break;
+                }
+
+                const rawEvent = workingBuffer.slice(0, separatorPosition);
+                workingBuffer = workingBuffer.slice(separatorPosition + 2);
+
+                if (rawEvent.trim() === '') {
+                    continue;
+                }
+
+                handleRawEvent(rawEvent);
+            }
+
+            return workingBuffer;
+        };
+
+        try {
+            while (!shouldStop) {
+                const { value, done } = await reader.read();
+                if (done) {
+                    break;
+                }
+
+                buffer += decoder.decode(value, { stream: true });
+                buffer = processBuffer(buffer);
+            }
+
+            buffer += decoder.decode();
+            buffer = processBuffer(buffer);
+
+            if (!shouldStop) {
+                const remaining = buffer.trim();
+                if (remaining !== '') {
+                    handleRawEvent(remaining);
+                }
+            }
+
+            if (!hasEnded) {
+                finishWithDone();
+            }
+        } finally {
+            shouldStop = true;
+
+            try {
+                await reader.cancel();
+            } catch (error) {
+                // Проглатываем ошибки при отмене чтения.
+            }
+        }
+    }
+
+    function initializeStreamingChat() {
+        const form = document.getElementById('llm-chat-stream-form');
+        const input = document.getElementById('llm-chat-stream-input');
+        const messagesContainer = document.getElementById('llm-chat-stream-messages');
+        const statusElement = document.getElementById('llm-chat-stream-status');
+
+        if (!form || !input || !messagesContainer) {
+            return;
+        }
+
+        if (form.dataset.enhanced === '1') {
+            return;
+        }
+        form.dataset.enhanced = '1';
+
+        const submitButton = form.querySelector('button[type="submit"]');
+        const streamUrl = form.dataset.streamUrl || '';
+        const systemMessage = form.dataset.systemMessage || '';
+        const isConfigured = form.dataset.configured === '1';
+
+        const baseStatusClasses = statusElement
+            ? statusElement.className
+                  .split(/\s+/)
+                  .filter((className) => className !== '' && (className === 'text-xs' || !className.startsWith('text-')))
+                  .join(' ')
+            : '';
+
+        const colors = {
+            info: 'text-slate-400',
+            success: 'text-sky-300',
+            warning: 'text-amber-300',
+            error: 'text-rose-300',
+        };
+
+        const conversation = [];
+        if (systemMessage !== '') {
+            conversation.push({ role: 'system', content: systemMessage });
+        }
+
+        const createBubble = function (role) {
+            const bubble = document.createElement('div');
+            bubble.className =
+                role === 'user'
+                    ? 'self-end max-w-xl rounded-2xl border border-slate-700/80 bg-slate-800/80 px-4 py-3 text-slate-100 shadow'
+                    : 'self-start max-w-xl rounded-2xl border border-sky-500/30 bg-sky-500/10 px-4 py-3 text-slate-100 shadow';
+
+            return bubble;
+        };
+
+        const updateBubbleText = function (bubble, text) {
+            while (bubble.firstChild) {
+                bubble.removeChild(bubble.firstChild);
+            }
+
+            const segments = String(text).split(/\n/);
+            segments.forEach((segment, index) => {
+                if (index > 0) {
+                    bubble.appendChild(document.createElement('br'));
+                }
+
+                bubble.appendChild(document.createTextNode(segment));
+            });
+        };
+
+        const setStatus = function (message, type) {
+            if (!statusElement) {
+                return;
+            }
+
+            const tone = colors[type] || colors.info;
+            const classes = [baseStatusClasses, tone].filter(Boolean).join(' ');
+            statusElement.className = classes;
+            statusElement.textContent = message;
+        };
+
+        const setPending = function (isPending) {
+            const shouldDisable = isPending || !isConfigured;
+
+            if (submitButton) {
+                submitButton.disabled = shouldDisable;
+                submitButton.setAttribute('aria-busy', isPending ? 'true' : 'false');
+            }
+
+            input.disabled = shouldDisable;
+
+            if (isPending) {
+                setStatus('Модель печатает ответ…', 'info');
+            }
+        };
+
+        if (!isConfigured) {
+            setStatus('Добавьте переменную окружения LLM_KEY, чтобы активировать чат.', 'warning');
+
+            return;
+        }
+
+        if (streamUrl === '') {
+            setStatus('Потоковый endpoint не настроен.', 'error');
+
+            return;
+        }
+
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+
+            const text = input.value.trim();
+            if (text === '') {
+                setStatus('Введите сообщение для модели.', 'warning');
+
+                return;
+            }
+
+            const userBubble = createBubble('user');
+            updateBubbleText(userBubble, text);
+            messagesContainer.appendChild(userBubble);
+            messagesContainer.scrollTop = messagesContainer.scrollHeight;
+
+            conversation.push({ role: 'user', content: text });
+            input.value = '';
+
+            const assistantBubble = createBubble('assistant');
+            messagesContainer.appendChild(assistantBubble);
+            messagesContainer.scrollTop = messagesContainer.scrollHeight;
+
+            let assistantText = '';
+            let streamActive = true;
+
+            setPending(true);
+            setStatus('Модель печатает ответ…', 'info');
+
+            startStreamingRequest(
+                streamUrl,
+                { messages: conversation },
+                {
+                    onToken: (chunk) => {
+                        if (!streamActive || chunk === '') {
+                            return;
+                        }
+
+                        assistantText += chunk;
+                        updateBubbleText(assistantBubble, assistantText);
+                        messagesContainer.scrollTop = messagesContainer.scrollHeight;
+                    },
+                    onDone: () => {
+                        if (!streamActive) {
+                            return;
+                        }
+
+                        streamActive = false;
+                        setPending(false);
+
+                        const trimmed = assistantText.trim();
+                        if (trimmed === '') {
+                            setStatus('Ответ модели пустой.', 'warning');
+
+                            return;
+                        }
+
+                        conversation.push({ role: 'assistant', content: trimmed });
+                        setStatus('Ответ получен.', 'success');
+                    },
+                    onError: (message) => {
+                        if (!streamActive) {
+                            return;
+                        }
+
+                        streamActive = false;
+                        setPending(false);
+
+                        if (assistantText === '') {
+                            assistantBubble.classList.add('border-rose-500/40', 'bg-rose-500/10', 'text-rose-100');
+                            updateBubbleText(assistantBubble, 'Ответ не был получен из-за ошибки.');
+                        }
+
+                        setStatus(message, 'error');
+                    },
+                },
+            ).catch(() => {
+                if (!streamActive) {
+                    return;
+                }
+
+                streamActive = false;
+                setPending(false);
+
+                if (assistantText === '') {
+                    assistantBubble.classList.add('border-rose-500/40', 'bg-rose-500/10', 'text-rose-100');
+                    updateBubbleText(assistantBubble, 'Не удалось связаться с моделью.');
+                }
+
+                setStatus('Не удалось отправить запрос. Проверьте подключение.', 'error');
+            });
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initializeStreamingChat, { once: true });
+    } else {
+        initializeStreamingChat();
+    }
+})();

--- a/src/Chat/StreamingConversationRelay.php
+++ b/src/Chat/StreamingConversationRelay.php
@@ -1,0 +1,390 @@
+<?php
+
+namespace App\Chat;
+
+/**
+ * Организует потоковую передачу сообщений между приложением и LLM.
+ */
+final class StreamingConversationRelay
+{
+    private const LLM_ENDPOINT = 'http://193.104.69.173/v1/chat/completions';
+
+    public const MODEL = 'qwen/qwen3-30b-a3b-2507';
+
+    private const EVENT_CONTINUE = 0;
+    private const EVENT_DONE = 1;
+    private const EVENT_ABORT = 2;
+
+    private readonly string $llmApiKey;
+
+    public function __construct(string $llmApiKey)
+    {
+        $this->llmApiKey = $llmApiKey;
+    }
+
+    /**
+     * Проверяет, настроен ли ключ доступа к модели.
+     */
+    public function isConfigured(): bool
+    {
+        return $this->llmApiKey !== '';
+    }
+
+    /**
+     * Выполняет потоковый запрос к модели и передаёт части ответа в колбэки.
+     *
+     * @param array<int, array{role: string, content: string}> $messages
+     * @param callable(string): void $onTextChunk
+     * @param callable(): void $onComplete
+     * @param callable(string): void $onError
+     */
+    public function stream(
+        array $messages,
+        callable $onTextChunk,
+        callable $onComplete,
+        callable $onError,
+    ): void {
+        if (!$this->isConfigured()) {
+            $onError('Ключ доступа к модели не настроен.');
+
+            return;
+        }
+
+        $requestPayload = [
+            'model' => self::MODEL,
+            'messages' => $this->formatMessagesForApi($messages),
+            'stream' => true,
+        ];
+
+        $requestBody = json_encode($requestPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (!is_string($requestBody)) {
+            $onError('Не удалось подготовить запрос к модели.');
+
+            return;
+        }
+
+        $headers = [
+            'Content-Type: application/json',
+            'Authorization: Bearer ' . $this->llmApiKey,
+        ];
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'header' => implode("\r\n", $headers),
+                'content' => $requestBody,
+                'ignore_errors' => true,
+                'timeout' => 60,
+            ],
+        ]);
+
+        error_clear_last();
+        $stream = @fopen(self::LLM_ENDPOINT, 'r', false, $context);
+        $responseHeaders = $http_response_header ?? [];
+
+        if ($stream === false) {
+            $lastError = error_get_last();
+            $message = is_array($lastError) && isset($lastError['message'])
+                ? (string) $lastError['message']
+                : 'Не удалось установить соединение с моделью.';
+
+            $onError($message);
+
+            return;
+        }
+
+        $statusCode = $this->extractStatusCode($responseHeaders);
+        if ($statusCode >= 400) {
+            $body = stream_get_contents($stream);
+            fclose($stream);
+
+            $onError($this->resolveErrorMessage($statusCode, $body));
+
+            return;
+        }
+
+        $this->relayStream($stream, $onTextChunk, $onComplete, $onError);
+    }
+
+    /**
+     * Запускает цикл чтения потока и пересылки событий клиенту.
+     *
+     * @param resource $stream
+     * @param callable(string): void $onTextChunk
+     * @param callable(): void $onComplete
+     * @param callable(string): void $onError
+     */
+    private function relayStream($stream, callable $onTextChunk, callable $onComplete, callable $onError): void
+    {
+        $buffer = '';
+        $isComplete = false;
+
+        while (($line = fgets($stream)) !== false) {
+            $buffer .= $line;
+
+            if (trim($line) !== '') {
+                continue;
+            }
+
+            $eventResult = $this->handleSseEvent($buffer, $onTextChunk, $onComplete, $onError);
+            $buffer = '';
+
+            if ($eventResult === self::EVENT_DONE) {
+                $isComplete = true;
+
+                break;
+            }
+
+            if ($eventResult === self::EVENT_ABORT) {
+                fclose($stream);
+
+                return;
+            }
+        }
+
+        if (!$isComplete && $buffer !== '') {
+            $eventResult = $this->handleSseEvent($buffer, $onTextChunk, $onComplete, $onError);
+
+            if ($eventResult === self::EVENT_DONE) {
+                $isComplete = true;
+            } elseif ($eventResult === self::EVENT_ABORT) {
+                fclose($stream);
+
+                return;
+            }
+        }
+
+        if (!$isComplete) {
+            $onComplete();
+        }
+
+        fclose($stream);
+    }
+
+    /**
+     * Обрабатывает отдельное SSE-событие и передаёт его содержимое в колбэки.
+     *
+     * @param callable(string): void $onTextChunk
+     * @param callable(): void $onComplete
+     * @param callable(string): void $onError
+     */
+    private function handleSseEvent(
+        string $eventChunk,
+        callable $onTextChunk,
+        callable $onComplete,
+        callable $onError,
+    ): int {
+        $dataString = $this->extractEventData($eventChunk);
+        if ($dataString === null) {
+            return self::EVENT_CONTINUE;
+        }
+
+        if ($dataString === '[DONE]') {
+            $onComplete();
+
+            return self::EVENT_DONE;
+        }
+
+        $decoded = json_decode($dataString, true);
+        if (!is_array($decoded)) {
+            return self::EVENT_CONTINUE;
+        }
+
+        if (isset($decoded['error'])) {
+            $onError($this->stringifyError($decoded['error']));
+
+            return self::EVENT_ABORT;
+        }
+
+        if (!isset($decoded['choices']) || !is_array($decoded['choices'])) {
+            return self::EVENT_CONTINUE;
+        }
+
+        $shouldComplete = false;
+
+        foreach ($decoded['choices'] as $choice) {
+            if (!is_array($choice)) {
+                continue;
+            }
+
+            $delta = $choice['delta'] ?? null;
+            if (is_array($delta) && array_key_exists('content', $delta)) {
+                $chunk = $this->stringifyContent($delta['content']);
+
+                if ($chunk !== '') {
+                    $onTextChunk($chunk);
+                }
+            }
+
+            if (isset($choice['finish_reason']) && $choice['finish_reason'] === 'stop') {
+                $shouldComplete = true;
+            }
+        }
+
+        if ($shouldComplete) {
+            $onComplete();
+
+            return self::EVENT_DONE;
+        }
+
+        return self::EVENT_CONTINUE;
+    }
+
+    /**
+     * Извлекает полезные данные из SSE-сообщения.
+     */
+    private function extractEventData(string $eventChunk): ?string
+    {
+        $lines = preg_split('/\r?\n/', $eventChunk) ?: [];
+        $dataLines = [];
+
+        foreach ($lines as $line) {
+            $trimmedLine = trim($line);
+
+            if ($trimmedLine === '' || $trimmedLine[0] === ':') {
+                continue;
+            }
+
+            if (str_starts_with($trimmedLine, 'data:')) {
+                $dataLines[] = ltrim(substr($trimmedLine, 5));
+            }
+        }
+
+        if ($dataLines === []) {
+            return null;
+        }
+
+        $payload = implode("\n", $dataLines);
+
+        return $payload === '' ? null : $payload;
+    }
+
+    /**
+     * Преобразует возможные варианты содержимого в текст.
+     *
+     * @param mixed $content
+     */
+    private function stringifyContent(mixed $content): string
+    {
+        if (is_string($content)) {
+            return $content;
+        }
+
+        if (is_array($content)) {
+            return $this->mergeTextParts($content);
+        }
+
+        return '';
+    }
+
+    /**
+     * Формирует текст ошибки из произвольной структуры.
+     */
+    private function stringifyError(mixed $error): string
+    {
+        if (is_array($error) && isset($error['message']) && is_string($error['message'])) {
+            return $error['message'];
+        }
+
+        if (is_string($error)) {
+            return $error;
+        }
+
+        return 'Модель вернула ошибку.';
+    }
+
+    /**
+     * Извлекает HTTP-статус из заголовков ответа.
+     *
+     * @param string[] $responseHeaders
+     */
+    private function extractStatusCode(array $responseHeaders): int
+    {
+        if ($responseHeaders === []) {
+            return 0;
+        }
+
+        $statusLine = $responseHeaders[0];
+        if (preg_match('/\s(\d{3})\s/', $statusLine, $matches) === 1) {
+            return (int) $matches[1];
+        }
+
+        return 0;
+    }
+
+    /**
+     * Подбирает понятное сообщение об ошибке по HTTP-статусу и телу ответа.
+     */
+    private function resolveErrorMessage(int $statusCode, string|false $body): string
+    {
+        if (is_string($body) && $body !== '') {
+            $decoded = json_decode($body, true);
+
+            if (is_array($decoded) && isset($decoded['error'])) {
+                return $this->stringifyError($decoded['error']);
+            }
+        }
+
+        return match ($statusCode) {
+            401 => 'Ошибка авторизации API. Проверьте правильность ключа API.',
+            403 => 'Доступ к модели запрещён. Проверьте права ключа API.',
+            default => 'Модель вернула ошибку. Код ответа: ' . $statusCode . '.',
+        };
+    }
+
+    /**
+     * Приводит сообщения диалога к формату, ожидаемому моделью.
+     *
+     * @param array<int, array{role: string, content: string}> $messages
+     *
+     * @return array<int, array{role: string, content: array<int, array{type: string, text: string}>}>
+     */
+    private function formatMessagesForApi(array $messages): array
+    {
+        $prepared = [];
+
+        foreach ($messages as $message) {
+            $prepared[] = [
+                'role' => $message['role'],
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => $message['content'],
+                    ],
+                ],
+            ];
+        }
+
+        return $prepared;
+    }
+
+    /**
+     * Склеивает текстовые части сложного содержимого в одну строку.
+     *
+     * @param array<int, mixed> $parts
+     */
+    private function mergeTextParts(array $parts): string
+    {
+        $fragments = [];
+
+        foreach ($parts as $part) {
+            if (!is_array($part)) {
+                continue;
+            }
+
+            $type = isset($part['type']) ? (string) $part['type'] : '';
+            if ($type !== 'text') {
+                continue;
+            }
+
+            $text = isset($part['text']) ? (string) $part['text'] : '';
+            if ($text === '') {
+                continue;
+            }
+
+            $fragments[] = $text;
+        }
+
+        return implode("\n", $fragments);
+    }
+}

--- a/src/Controller/ChatStreamingController.php
+++ b/src/Controller/ChatStreamingController.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Controller;
+
+use App\Chat\StreamingConversationRelay;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Страница стримингового LLM-чата и API для потокового ответа модели.
+ */
+final class ChatStreamingController extends AbstractController
+{
+    private const SYSTEM_MESSAGE = 'Вы — дружелюбный ассистент Codex, который помогает с вопросами по проектам и кодированию.';
+
+    private readonly StreamingConversationRelay $conversationRelay;
+
+    public function __construct()
+    {
+        $apiKey = (string) ($_ENV['LLM_KEY'] ?? $_SERVER['LLM_KEY'] ?? getenv('LLM_KEY') ?? '');
+        $this->conversationRelay = new StreamingConversationRelay($apiKey);
+    }
+
+    /**
+     * Показывает страницу чата с потоковым отображением ответа модели.
+     */
+    #[Route('/chat2', name: 'app_llm_chat_stream')]
+    public function page(): Response
+    {
+        $isConfigured = $this->conversationRelay->isConfigured();
+
+        return $this->render('llm_chat_streaming.html.twig', [
+            'pageTitle' => 'LLM-чат (стриминг)',
+            'llmConfigured' => $isConfigured,
+            'modelName' => StreamingConversationRelay::MODEL,
+            'systemMessage' => self::SYSTEM_MESSAGE,
+            'streamEndpoint' => $this->generateUrl('app_llm_chat_stream_stream'),
+        ]);
+    }
+
+    /**
+     * Принимает историю диалога и возвращает поток SSE с частями ответа модели.
+     */
+    #[Route('/chat2/stream', name: 'app_llm_chat_stream_stream', methods: ['POST'])]
+    public function streamConversation(Request $request): Response
+    {
+        if (!$this->conversationRelay->isConfigured()) {
+            return new JsonResponse([
+                'error' => 'LLM_KEY не настроен. Обратитесь к администратору для указания ключа доступа.',
+            ], Response::HTTP_SERVICE_UNAVAILABLE);
+        }
+
+        $contentType = $request->headers->get('Content-Type', '');
+        if (!str_contains($contentType, 'application/json')) {
+            return new JsonResponse([
+                'error' => 'Неверный тип содержимого. Ожидается application/json.',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $content = $request->getContent();
+        if ($content === '') {
+            return new JsonResponse([
+                'error' => 'Пустой запрос. Ожидалось содержимое JSON.',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $decoded = json_decode($content, true);
+        if (!is_array($decoded)) {
+            return new JsonResponse([
+                'error' => 'Некорректный формат запроса. Ожидался JSON.',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $messages = $decoded['messages'] ?? null;
+        if (!is_array($messages)) {
+            return new JsonResponse([
+                'error' => 'Поле messages обязательно и должно быть массивом.',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $normalizedMessages = [];
+        foreach ($messages as $message) {
+            if (!is_array($message)) {
+                continue;
+            }
+
+            $role = isset($message['role']) ? trim((string) $message['role']) : '';
+            $text = isset($message['content']) ? trim((string) $message['content']) : '';
+
+            if ($role === '' || $text === '') {
+                continue;
+            }
+
+            $normalizedMessages[] = [
+                'role' => $role,
+                'content' => $text,
+            ];
+        }
+
+        if ($normalizedMessages === []) {
+            return new JsonResponse([
+                'error' => 'Не удалось определить сообщения для отправки в модель.',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $response = new StreamedResponse(function () use ($normalizedMessages) {
+            $sendEvent = static function (array $payload): void {
+                $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                if (!is_string($json)) {
+                    return;
+                }
+
+                echo 'data: ' . $json . "\n\n";
+
+                if (function_exists('ob_flush')) {
+                    @ob_flush();
+                }
+
+                flush();
+            };
+
+            $this->conversationRelay->stream(
+                $normalizedMessages,
+                static function (string $chunk) use ($sendEvent): void {
+                    if ($chunk === '') {
+                        return;
+                    }
+
+                    $sendEvent([
+                        'event' => 'token',
+                        'text' => $chunk,
+                    ]);
+                },
+                static function () use ($sendEvent): void {
+                    $sendEvent([
+                        'event' => 'done',
+                    ]);
+                },
+                static function (string $errorMessage) use ($sendEvent): void {
+                    $sendEvent([
+                        'event' => 'error',
+                        'message' => $errorMessage,
+                    ]);
+                },
+            );
+        });
+
+        $response->headers->set('Content-Type', 'text/event-stream');
+        $response->headers->set('Cache-Control', 'no-cache');
+        $response->headers->set('Connection', 'keep-alive');
+        $response->headers->set('X-Accel-Buffering', 'no');
+
+        return $response;
+    }
+}

--- a/templates/llm_chat_streaming.html.twig
+++ b/templates/llm_chat_streaming.html.twig
@@ -1,0 +1,98 @@
+{# Шаблон страницы LLM-чата с потоковым выводом ответа модели. #}
+{% extends 'base.html.twig' %}
+
+{% block html_attributes %} lang="ru" class="h-full bg-slate-950"{% endblock %}
+{% block body_attributes %} class="min-h-full bg-slate-950 text-slate-100"{% endblock %}
+
+{% block title %}{{ pageTitle }}{% endblock %}
+
+{% block head_extra %}
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    <script src="/js/llm-chat-streaming.js" defer></script>
+{% endblock %}
+
+{% block body %}
+    <div class="min-h-full flex flex-col">
+        <header class="border-b border-slate-800/60 bg-slate-900/70 backdrop-blur">
+            <div class="mx-auto w-full max-w-5xl px-6 py-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-wider text-sky-400">Codex Playground</p>
+                    <h1 class="text-2xl font-semibold text-white">{{ pageTitle }}</h1>
+                </div>
+                <div class="flex flex-col items-start gap-3 text-sm text-slate-400 sm:flex-row sm:items-center">
+                    <a href="{{ path('app_home') }}" class="inline-flex items-center gap-2 rounded-full border border-slate-700/80 px-4 py-2 transition hover:border-sky-400 hover:text-sky-300">
+                        <span aria-hidden="true">←</span>
+                        <span>На главную</span>
+                    </a>
+                    <a href="{{ path('app_llm_chat') }}" class="inline-flex items-center gap-2 rounded-full border border-slate-700/80 px-4 py-2 transition hover:border-sky-400 hover:text-sky-300">
+                        <span aria-hidden="true">⇆</span>
+                        <span>К классическому чату</span>
+                    </a>
+                    <div class="flex flex-col text-left sm:text-right">
+                        <span class="text-xs uppercase tracking-wide text-slate-500">Модель</span>
+                        <span class="font-mono text-slate-300">{{ modelName }}</span>
+                    </div>
+                </div>
+            </div>
+        </header>
+        <main class="flex-1">
+            <div class="mx-auto flex h-full max-w-5xl flex-col gap-6 px-6 py-10">
+                <section class="flex flex-1 flex-col rounded-3xl border border-slate-800/70 bg-slate-900/60 px-6 py-8 shadow-xl backdrop-blur">
+                    <div class="space-y-4 text-sm text-slate-300">
+                        <p>В этой версии ответ модели появляется по мере генерации. Наблюдайте за токенами в реальном времени.</p>
+                        {% if not llmConfigured %}
+                            <div class="rounded-2xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-amber-200 text-sm">
+                                Ключ доступа к модели ещё не настроен. Добавьте переменную окружения <code class="font-mono text-xs text-amber-100 bg-amber-500/20 px-2 py-1 rounded">LLM_KEY</code> и обновите страницу.
+                            </div>
+                        {% else %}
+                            <p class="text-xs text-slate-500">Сообщение ассистента будет дополняться прямо в чате. Можно задавать новые вопросы по завершении вывода.</p>
+                        {% endif %}
+                    </div>
+                    <div class="mt-6 flex-1 overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/60">
+                        <div id="llm-chat-stream-messages" class="flex h-full flex-col gap-4 overflow-y-auto px-6 py-6 text-sm leading-relaxed">
+                            <div class="self-start max-w-xl rounded-2xl border border-sky-500/30 bg-sky-500/10 px-4 py-3 text-slate-200 shadow-sm">
+                                Привет! В этой версии я отвечаю по частям. Задайте вопрос, и увидите, как формируется ответ.
+                            </div>
+                        </div>
+                    </div>
+                    <form
+                        id="llm-chat-stream-form"
+                        action="{{ streamEndpoint }}"
+                        method="post"
+                        class="mt-6 flex flex-col gap-4"
+                        data-system-message="{{ systemMessage }}"
+                        data-configured="{{ llmConfigured ? '1' : '0' }}"
+                        data-stream-url="{{ streamEndpoint }}"
+                    >
+                        <label class="flex flex-col gap-2 text-sm text-slate-300" for="llm-chat-stream-input">
+                            Сообщение
+                            <textarea
+                                id="llm-chat-stream-input"
+                                name="message"
+                                rows="3"
+                                class="w-full rounded-2xl border border-slate-800/80 bg-slate-950/60 px-4 py-3 font-medium text-slate-100 placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-400/40"
+                                placeholder="Опишите задачу или задайте вопрос…"
+                                {% if not llmConfigured %}disabled{% endif %}
+                            ></textarea>
+                        </label>
+                        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <p id="llm-chat-stream-status" class="min-h-[1.5rem] text-xs text-slate-500"></p>
+                            <button
+                                type="submit"
+                                class="inline-flex items-center justify-center gap-2 rounded-full bg-sky-500 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg transition hover:bg-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-300/60 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
+                                {% if not llmConfigured %}disabled{% endif %}
+                            >
+                                Отправить
+                            </button>
+                        </div>
+                    </form>
+                </section>
+            </div>
+        </main>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- introduce a streaming conversation relay to proxy SSE chunks from the LLM API
- add a dedicated chat controller, template, and frontend script for the /chat2 streaming interface

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68cee58844e0832e915ddf8fd3f2a11c