### PR TITLE
Enable sending chat messages with Enter key

### DIFF
--- a/public/js/llm-chat.js
+++ b/public/js/llm-chat.js
@@ -92,6 +92,28 @@
             return;
         }
 
+        input.addEventListener('keydown', (event) => {
+            if (event.key !== 'Enter' || event.isComposing) {
+                return;
+            }
+
+            if (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) {
+                return;
+            }
+
+            if (submitButton && submitButton.disabled) {
+                return;
+            }
+
+            event.preventDefault();
+
+            if (typeof form.requestSubmit === 'function') {
+                form.requestSubmit();
+            } else {
+                form.submit();
+            }
+        });
+
         form.addEventListener('submit', async (event) => {
             event.preventDefault();
 


### PR DESCRIPTION
## Summary
- submit the chat form when Enter is pressed in the textarea
- ignore Enter when used with modifier keys or while a request is pending
- fall back to a normal form submission if requestSubmit is unavailable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cef70e9ac4832e9e3050d897842e88