### PR TITLE
Link homepage tiles to chat demos

### DIFF
--- a/src/Controller/HelloController.php
+++ b/src/Controller/HelloController.php
@@ -56,20 +56,16 @@ final class HelloController extends AbstractController
             'currentSqliteDateTime' => $currentDateTime,
             'highlights' => [
                 [
-                    'title' => 'Symfony',
-                    'description' => 'Современный PHP-фреймворк, который помогает строить мощные и устойчивые приложения.',
+                    'title' => 'LLM-чат Codex',
+                    'description' => 'Общайтесь с моделью напрямую из браузера и получайте развёрнутые ответы на вопросы.',
+                    'url' => $this->generateUrl('app_llm_chat'),
+                    'cta' => 'Открыть обычный чат',
                 ],
                 [
-                    'title' => 'Tailwind CSS',
-                    'description' => 'Утилитарный CSS-фреймворк, позволяющий быстро создавать аккуратные интерфейсы без лишнего кода.',
-                ],
-                [
-                    'title' => 'Быстрый старт',
-                    'description' => 'Используйте примеры, чтобы ускорить знакомство с фреймворком и его экосистемой.',
-                ],
-                [
-                    'title' => 'Комьюнити',
-                    'description' => 'Делитесь находками и задавайте вопросы сообществу Codex и Symfony.',
+                    'title' => 'Стриминговый чат',
+                    'description' => 'Наблюдайте за ответом модели в реальном времени благодаря потоковой передаче.',
+                    'url' => $this->generateUrl('app_llm_chat_stream'),
+                    'cta' => 'Перейти к стримингу',
                 ],
             ],
         ]);

--- a/templates/homepage.html.twig
+++ b/templates/homepage.html.twig
@@ -36,14 +36,26 @@
                     </p>
                     <div class="grid gap-4 sm:grid-cols-2">
                         {% for highlight in highlights %}
-                            <div class="rounded-xl border border-slate-700/80 bg-slate-900/40 p-5">
-                                <h2 class="text-lg font-medium text-sky-300 mb-2">
-                                    {{ highlight.title }}
-                                </h2>
-                                <p class="text-sm text-slate-400">
-                                    {{ highlight.description }}
-                                </p>
-                            </div>
+                            <a
+                                href="{{ highlight.url }}"
+                                class="group flex h-full flex-col justify-between rounded-xl border border-slate-700/80 bg-slate-900/40 p-5 transition hover:border-sky-400/80 hover:bg-slate-900/70 hover:shadow-lg"
+                            >
+                                <div>
+                                    <h2 class="text-lg font-medium text-sky-300 mb-2">
+                                        {{ highlight.title }}
+                                    </h2>
+                                    <p class="text-sm text-slate-400">
+                                        {{ highlight.description }}
+                                    </p>
+                                </div>
+                                <span class="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-sky-300 transition group-hover:text-sky-200">
+                                    {{ highlight.cta }}
+                                    <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                        <path d="M5 12h14" />
+                                        <path d="m13 6 6 6-6 6" />
+                                    </svg>
+                                </span>
+                            </a>
                         {% endfor %}
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- turn the homepage highlight tiles into links that lead to the chat demos
- update the highlight data to surface both the standard and streaming chat options

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68cef4b26c60832eaee7357853c63d9c